### PR TITLE
Bugfix

### DIFF
--- a/frontend/src/javascripts/components/RenderView.js
+++ b/frontend/src/javascripts/components/RenderView.js
@@ -106,7 +106,7 @@ class RenderView extends Component{
 
   componentDidMount() {
     document.getElementById("render-view__reset-btn").addEventListener("click", e => {
-      if ((this.clickState.stage !== stages.BLOCKED) && (this.clickState.stage !== stages.BLOCKED_AFTER_1ST) && (this.clickState.stage !== stages.SELECTED_2ND)){
+      if ((this.clickState.stage !== stages.BLOCKED) && (this.clickState.stage !== stages.BLOCKED_AFTER_1ST) && (this.clickState.stage !== stages.SELECTED_2ND) && (this.clickState.stage !== stages.SLIDER_DISPLAYED) && (this.clickState.stage !== stages.LOADED_1ST_IMG)){
         this.clickState.clean(
           this.props.action.interpolate.reset
         )
@@ -114,13 +114,13 @@ class RenderView extends Component{
       }
     })
     this.props.emitter.addListener(ce.preview, (id, openSideBar) => {
-      if (!this.props.state.interpolate.isShowSlider && !this.props.state.interpolate.isSliderNodesReady && (this.clickState.stage !== stages.BLOCKED) && (this.clickState.stage !== stages.BLOCKED_AFTER_1ST) && (this.clickState.stage !== stages.BLOCKED_BY_RESET) && (this.clickState.stage !== stages.SELECTED_2ND)){
+      if (!this.props.state.interpolate.isShowSlider && !this.props.state.interpolate.isSliderNodesReady && (this.clickState.stage !== stages.BLOCKED) && (this.clickState.stage !== stages.BLOCKED_AFTER_1ST) && (this.clickState.stage !== stages.BLOCKED_BY_RESET) && (this.clickState.stage !== stages.SELECTED_2ND) && (this.clickState.stage !== stages.SLIDER_DISPLAYED) && (this.clickState.stage !== stages.LOADED_1ST_IMG)){
         this.clickState.block()
         this.props.emitter.emit('zoomToImage', id, true)
       }
     })
     this.props.emitter.addListener(ce.select, (id, openSideBar) => {
-      if (!this.props.state.interpolate.isCanSelect(id) || (this.clickState.stage === stages.BLOCKED_BY_RESET) || (this.clickState.stage === stages.SELECTED_2ND)) {
+      if (!this.props.state.interpolate.isCanSelect(id) || (this.clickState.stage === stages.BLOCKED_BY_RESET) || (this.clickState.stage === stages.SELECTED_2ND) || (this.clickState.stage === stages.SLIDER_DISPLAYED) || (this.clickState.stage === stages.LOADED_1ST_IMG)) {
         return;
       }
       if ((this.clickState.stage === stages.SELECTED_1ST) || (this.clickState.stage === stages.CLEAN) || (this.clickState.stage === stages.PREVIEWED) || (this.clickState.stage === stages.PREVIEWED_AFTER_1ST)){
@@ -143,6 +143,7 @@ class RenderView extends Component{
     })
     this.props.emitter.addListener('interpolate-images-ready', () => {
         this.props.action.interpolate.notifyImagesReady()
+        this.clickState.load_img()
     })
     fetch(DATAPOINT_URL).then((res) => {
       return res.json()
@@ -592,9 +593,9 @@ class RenderView extends Component{
     this.props.emitter.addListener('zoomToImage', (id, openSideBar) => {
       // Preload the image results JSON file so it'll show instantly
       // when the sidebar is opened
-      
+
       this.props.emitter.emit('update-lastZoomId', id)
-      
+
       preloadImage(getVisionJsonURL(id))
 
       cameraAnimationQueue = cameraAnimationQueue
@@ -819,12 +820,12 @@ class RenderView extends Component{
           }
         }
       }
-      
+
       // Unblock zoom-to-image if user has panned away
       if (controls.hasRecentlyRotated){
           this.props.emitter.emit('update-lastZoomId', '')
       }
-      
+
     }, false)
 
     this._container.addEventListener('mousewheel', () => {
@@ -845,7 +846,7 @@ class RenderView extends Component{
       forwardVec.multiplyScalar(delta)
 
       cameraTargetPosition.add(forwardVec)
-      
+
       // Unblock zoom-to-image if user has zoomed away
       this.props.emitter.emit('update-lastZoomId', '')
     })
@@ -853,6 +854,7 @@ class RenderView extends Component{
     const m1 = new THREE.Matrix4()
 
     const tick = (delta) => {
+      //console.log(this.clickState.stage) //This line is great for debugging
       if ((this.clickState.stage === stages.INTERPOLATED) || (this.clickState.stage === stages.SLIDER_DISPLAYED) || (this.clickState.stage === stages.SLIDER_MOVING) || (this.clickState.stage === stages.SLIDER_STOPPED) || (this.clickState.stage === stages.BLOCKED_BY_RESET)){
         controls.enablePan = false
       }

--- a/frontend/src/javascripts/misc/clickState.js
+++ b/frontend/src/javascripts/misc/clickState.js
@@ -11,7 +11,9 @@ export const stages = {
   SLIDER_STOPPED: "SLIDER_STOPPED",
   BLOCKED: "BLOCKED",
   BLOCKED_AFTER_1ST: "BLOCKED_AFTER_1ST",
-  BLOCKED_BY_RESET: "BLOCKED_BY_RESET"
+  BLOCKED_BY_RESET: "BLOCKED_BY_RESET",
+  LOADED_1ST_IMG: "LOADED_1ST_IMG",
+  LOADED_2ND_IMG: "LOADED_2ND_IMG"
 };
 
 export const isMouseHit = (mouseX, mouseY, x, y, size) => ((mouseX - x)**2)/(size*size/4) +((mouseY - y)**2)/(size*size/4) < 1;
@@ -80,6 +82,17 @@ export default class ClickState {
 
   unblock_reset() { //This gets called when the promises in trackNode in RenderView.js get resolved, which is at the end of camera operation.
     this.state.stage = stages.CLEAN;
+  }
+
+  load_img() {
+    switch(this.state.stage) {
+      case stages.SLIDER_DISPLAYED: //This reads oddly but, think of "slider displayed" state as more like, attempting to display slider.
+        this.state.stage = stages.LOADED_1ST_IMG;
+        break;
+      case stages.LOADED_1ST_IMG:
+        this.state.stage = stages.LOADED_2ND_IMG;
+        break;
+    }
   }
 
   displaySlider(pinSliderDispatch, params) {


### PR DESCRIPTION
#25 

Summary: Make sure that reset button only works when both images are fully loaded, by introducing 2 new states called LOADED_1ST_IMG and LOADED_2ND_IMG.

Make sure that the blocking window is more thorough for events such as preview/select/reset as a result of introducing the 2 new states.

Line109: Reset only works after state "LOADED_2ND_IMG" onward.

Line117/123: preview/selecting effectively dead